### PR TITLE
Support HTTPS websites

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-contrib-uglify": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-express": "^1.4.1",
-    "grunt-jscs": "^2.3.0"
+    "grunt-jscs": "^2.3.0",
+    "grunt-parallel": "^0.4.1"
   }
 }

--- a/src/ga-lite.js
+++ b/src/ga-lite.js
@@ -5,7 +5,7 @@
         window.galite = window.galite || {};
         var req = new XMLHttpRequest();
         var urlBase = (
-            '//www.google-analytics.com/collect?' +
+            'https://www.google-analytics.com/collect?' +
             'cid=' + (localStorage.uid = localStorage.uid || Math.random() + '.' + Math.random()) +
             '&v=1' +
             '&tid=' + galite.UA +

--- a/src/ga-lite.js
+++ b/src/ga-lite.js
@@ -1,11 +1,11 @@
 (function(window, localStorage, navigator, screen, document, encodeURIComponent) {
     window.addEventListener('load', function() {
         var pageLoadedTimestamp = new Date().getTime();
-        
+
         window.galite = window.galite || {};
         var req = new XMLHttpRequest();
         var urlBase = (
-            'http://www.google-analytics.com/collect?' +
+            '//www.google-analytics.com/collect?' +
             'cid=' + (localStorage.uid = localStorage.uid || Math.random() + '.' + Math.random()) +
             '&v=1' +
             '&tid=' + galite.UA +
@@ -13,7 +13,7 @@
             '&ul=en-us' +
             '&de=UTF-8'
         );
-        
+
         var getOptionalStr = function(values) {
             var str = '';
             for (var i in values) {
@@ -24,7 +24,7 @@
             }
             return str;
         };
-        
+
         var optional = {
             'dt': [document.title],
             'sd': [screen.colorDepth, '-bit'],
@@ -62,10 +62,10 @@
                 );
             };
         };
-        
+
         // Deplay the page load event by 100ms
         setTimeout(eventBuilder('pageview'), 100);
-        
+
         /**
          * Note:
          * unload event does not fire on:


### PR DESCRIPTION
# This PR handles Issue: #4 

I did two things in this PR, mostly because the first one was extremely minor and I did not want to have to open a PR just for a package addition that npm was asking me for. Here is the breakdown:

## 1. Added `grunt-parallel` to `package.json`.

After running `npm install` on a clean `git clone`, I ran `grunt`. It gave me a warning saying that I did not have `grunt-parallel` installed locally and that I should. So, I installed it with the `--save-dev` option and am committing it for others to bypass this warning.

## 2. Removed protocol from google-analytics.com file. (This is the reason for the PR)

If a user wants to use this script on a HTTPS website they get an error because the call is currently using HTTP. I removed the protocol from the file so that it will use whatever protocol the website is already using to get this file.