### PR TITLE
Fallback to AJAX if sendBeacon() returns false (too much data)

### DIFF
--- a/src/ga-lite.js
+++ b/src/ga-lite.js
@@ -53,9 +53,16 @@
         }
 
         var sendTo = function(url) {
+            //sendBeacon() will return false if you attempt to send too much
+            //data. This limit is per-page for some browsers such as Chrome.
+            var useFallback = true;
             if (navigator.sendBeacon) {
-                navigator.sendBeacon(url);
-            } else {
+                if (navigator.sendBeacon(url)) {
+                    useFallback = false;
+                }
+            }
+
+            if (useFallback) {
                 try {
                     req.open('GET', url, false);
                     req.send();


### PR DESCRIPTION
`navigator.sendBeacon()` can return false if too much data is sent. For Chrome, "too much data" is actually per-page (or navigation context) and not per request. So if other callers use `navigator.sendBeacon()` before this call it is possible for this method to fail. In that case we should fallback to regular AJAX requests.

[Notes from spec editor](https://github.com/w3c/beacon/issues/38#issue-185538456)

Although exceeding the data limit (seems to be 64KB for all browsers) is a really small sample right now the [data shows](https://www.chromestatus.com/metrics/feature/timeline/popularity/495) this is on the rise.