### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can install ga-lite to your project by adding the following code to the ende
 of your HTML `<body>`:
 
 ```html
-<script src="https://cdn.jsdelivr.net/ga-lite/latest/ga-lite.min.js" async></script>
+<script src="https://cdn.jsdelivr.net/npm/ga-lite@1.1.2/dist/ga-lite.min.js" async></script>
 <script>
 var galite = galite || {};
 galite.UA = 'UA-XXXXXX'; // Insert your tracking code here

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ga-lite",
   "version": "1.1.2",
   "description": "Small, cacheable subset of Google Analytics JS client",
+  "jsdelivr": "dist/ga-lite.min.js",
   "main": " ",
   "scripts": {
     "test": "echo \"Error: no test specified but that's ok\"",


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.
The link will only work if you exclude `dist` from `npmignore`.
I also changed the default file to `dist/ga-lite.min.js`.

You can find links for all files at https://www.jsdelivr.com/package/npm/ga-lite.

Feel free to ping me if you have any questions regarding this change.