### PR TITLE
Remove node-url from devDependencies, use node's URL module instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "mocha-webpack": "^0.7.0",
     "nyc": "^11.2.1",
     "uglify-js": "^3.1.2",
-    "url": "^0.11.0",
     "wdio-mocha-framework": "^0.5.10",
     "wdio-phantomjs-service": "^0.2.2",
     "wdio-spec-reporter": "^0.1.0",


### PR DESCRIPTION
In unit tests, we can use [node's native URL module](https://nodejs.org/dist/latest-v11.x/docs/api/url.html) instead of depending on the [custom node-url module from 2015](https://github.com/defunctzombie/node-url/).