### PR TITLE
Fix node.js SSR

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const webpack = require("webpack");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 module.exports = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,8 @@ module.exports = {
     filename: "[name].js",
     libraryTarget: "umd",
     libraryExport: "default",
-    library: ["galite"]
+    library: ["galite"],
+    globalObject: 'this'
   },
   target: "web",
   optimization: {


### PR DESCRIPTION
Webpack just got updated to latest version. The last working version
(2.0.1) did use `this` as the global object:

https://github.com/jehna/ga-lite/blob/2.0.1/dist/ga-lite.js#L10

...while the latest version uses `window`:

https://github.com/jehna/ga-lite/blob/2.0.4/dist/ga-lite.js#L10

I think webpack had changed the default configuration to `window` at
some point, as their documentation now states:

> When targeting a library, especially the `libraryTarget` is`'umd'`,
> this option indicates what global object will be used to mount the
> library. To make UMD build available on both browsers and Node.js, set
> `output.globalObject` option to `'this'`.

Source: https://webpack.js.org/configuration/output/#outputglobalobject

This probably caused the issue #76, which will be fixed by this commit.