### PR TITLE
Fix sendBeacon throwing error

### DIFF
--- a/src/send-to.js
+++ b/src/send-to.js
@@ -1,8 +1,12 @@
 export default function sendTo(url) {
   if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
-    const didSucceed = navigator.sendBeacon(url)
-    if (didSucceed) {
-      return
+    try {
+      const didSucceed = navigator.sendBeacon(url)
+      if (didSucceed) {
+        return
+      }
+    } catch (e) {
+      // ignore
     }
   }
 


### PR DESCRIPTION
As reported at issue #380, the `navigator.sendBeacon` may throw an error if the URL is invalid:
https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch

The original issue also mentions binding the `sendBeacon` to the `navigator` object, but as our code is not using `sendBeacon` without calling it under `navigator`, it should not be a problem. Even if it were, the try-catch would catch both cases.

Fixes #380