### PR TITLE
Don't skip zero param values

### DIFF
--- a/src/fields-to-params.js
+++ b/src/fields-to-params.js
@@ -2,7 +2,7 @@ export default function fieldsToParams(fieldsObject) {
   const params = {}
   for (const fieldName in fieldsObject) {
     const paramValue = fieldsObject[fieldName]
-    if (!paramValue) {
+    if (paramValue == null || paramValue === '') {
       continue
     }
 


### PR DESCRIPTION
I'm not sure whether this is necessary but I've noticed that unlike the official script, `ev` is completely missing if the value is `0`. This seems like it's not right?